### PR TITLE
Minor changes to deprecation functionality

### DIFF
--- a/fresh/feat.q
+++ b/fresh/feat.q
@@ -16,7 +16,7 @@ fresh.feat.absEnergy:{[data]
 // @fileoverview Calculate the absolute sum of the differences between 
 //   successive data points
 // @param data {num[]} Numerical data points
-// @return {num} Absolute sum of differences
+// @return {float} Absolute sum of differences
 fresh.feat.absSumChange:{[data]
   sum abs 1_deltas data
   }
@@ -332,7 +332,7 @@ fresh.feat.linTrend:{[data]
 //   series is greater than the series mean
 // @param data {num[]} Numerical data points
 // @return {bool} Is longest subsequence greater than the mean
-fresh.feat.longStrikeAbvMean:{[data]
+fresh.feat.longStrikeAboveMean:{[data]
   max 0,fresh.i.getLenSeqWhere data>avg data
   }
 
@@ -342,7 +342,7 @@ fresh.feat.longStrikeAbvMean:{[data]
 //   series is less than the series mean
 // @param data {num[]} Numerical data points
 // @return {bool} Is longest subsequence less than the mean
-fresh.feat.longStrikeBelMean:{[data]
+fresh.feat.longStrikeBelowMean:{[data]
   max 0,fresh.i.getLenSeqWhere data<avg data
   }
 
@@ -543,7 +543,7 @@ fresh.feat.skewness:{[data]
 // @category freshFeat
 // @fileoverview Calculate the cross power spectral density of a time series
 // @param data {num[]} Numerical data points
-// @param coeff {int} Frequency at which calculation is preformed
+// @param coeff {int} Frequency at which calculation is performed
 // @return {float} Cross power spectral density of data at given coeff
 fresh.feat.spktWelch:{[data;coeff]
   fresh.i.welch[data;`nperseg pykw 256&count data][@;1][`]coeff
@@ -635,6 +635,6 @@ fresh.feat.var:{[data]
 //   deviation
 // @param data {num[]} Numerical data points
 // @return {bool} Indicates if variance is larger than standard deviation
-fresh.feat.varAbvStdDev:{[data]
+fresh.feat.varAboveStdDev:{[data]
   1<var data
   }

--- a/fresh/utils.q
+++ b/fresh/utils.q
@@ -88,18 +88,19 @@ fresh.i.pacf:stattools`:pacf
 fresh.i.adFuller:stattools`:adfuller
 
 // Python features
-fresh.i.pyFeat:`aggautocorr`augfuller`fftaggreg`fftcoeff`numcwtpeaks,
-  `partautocorrelation`spktwelch
+fresh.i.pyFeat:`aggAutoCorr`augFuller`fftAggReg`fftCoeff`numCwtPeaks,
+  `partAutoCorrelation`spktWelch
 
 // Extract utilities
 
 // @private
 // @kind function
 // @category freshUtility
-// @fileoverview Create a mapping between the functions and columns in which 
-//   they are to be applied to 
-// @param map {sym[]} Contains functions to be applied along with the column
-//   to apply it to 
+// @fileoverview Create a mapping between the functions and columns on which
+//   they are to be applied
+// @param map {(sym[];sym[])} Two element list where first element is the
+//   columns to which functions are to be applied and the second element is
+//   the name of the function in the .ml.fresh.feat namespace to be applied
 // @return {sym[]} A mapping of the functions to be applied to each column
 fresh.i.colMap:{[map]
   updFunc:flip (` sv'`.ml.fresh.feat,'map[;1];map[;0]);

--- a/graph/init.q
+++ b/graph/init.q
@@ -3,3 +3,6 @@
 .ml.loadfile`:graph/pipeline.q
 .ml.loadfile`:graph/modules/saving.q
 .ml.loadfile`:graph/modules/loading.q
+
+.ml.loadfile`:util/utils.q
+.ml.i.deprecWarning`graph

--- a/ml.q
+++ b/ml.q
@@ -3,3 +3,17 @@
 version:@[{TOOLKITVERSION};`;`development]
 path:{string`ml^`$@[{"/"sv -1_"/"vs ssr[;"\\";"/"](-3#get .z.s)0};`;""]}`
 loadfile:{$[.z.q;;-1]"Loading ",x:_[":"=x 0]x:$[10=type x;;string]x;system"l ",path,"/",x;}
+
+// The following functionality should be available for all initialized sections of the library
+
+// @private
+// @kind function
+// @category utility
+// @fileoverview If set to `1b` deprecation warnings are ignored
+i.ignoreWarning:0b
+
+// @private
+// @kind function
+// @category utilities
+// @fileoverview Change ignoreWarnings
+updateIgnoreWarning:{[]i.ignoreWarning::not i.ignoreWarning}

--- a/optimize/init.q
+++ b/optimize/init.q
@@ -3,3 +3,5 @@ loadfile`:util/utils.q
 loadfile`:util/utilities.q
 loadfile`:optimize/utils.q
 loadfile`:optimize/optimize.q
+
+.ml.i.deprecWarning`optimize

--- a/timeseries/init.q
+++ b/timeseries/init.q
@@ -4,6 +4,6 @@
 .ml.loadfile`:timeseries/fit.q
 .ml.loadfile`:timeseries/predict.q
 .ml.loadfile`:timeseries/misc.q
-.ml.loadfile`:util/utils.q
 
-.ml.i.deprecWarning[`timeSeries]
+.ml.loadfile`:util/utils.q
+.ml.i.deprecWarning`timeSeries

--- a/util/preproc.q
+++ b/util/preproc.q
@@ -157,7 +157,7 @@ fillTab:{[tab;groupCol;timeCol;dict]
 // @category preprocessing
 // @fileoverview Fit one-hot encoding model to categorical data
 // @param tab {tab} Numerical and non numerical data
-// @param symCols {sym[]} Columns to apply coding to
+// @param symCols {sym[]} Columns to apply encoding to
 // @return {dict} modelInfo containing mapping information and a projection of
 //   the prediction function to be applied to data
 oneHot.fit:{[tab;symCols]
@@ -291,7 +291,7 @@ labelEncode.predict:{[data;map]
 // @return {int[]} List is encoded to an integer representation 
 labelEncode.fitPredict:{[data]
   encoder:labelEncode.fit data;
-  encoder.predict data
+  encoder[`predict]data
   }
 
 // @kind function

--- a/util/utilities.q
+++ b/util/utilities.q
@@ -178,9 +178,3 @@ df2tabTimezone:{[tab;local;qObj]
 // @param tab {<} An embedPy representation of a Pandas dataframe
 // @return {<} a q table
 df2tab:df2tabTimezone[;0b;0b]
-
-// @private
-// @kind function
-// @category utilities
-// @fileoverview Change ignoreWarnings
-updateIgnoreWarning:{[]i.ignoreWarning::not i.ignoreWarning}

--- a/util/utils.q
+++ b/util/utils.q
@@ -490,12 +490,6 @@ i.inputError:{[input]
 
 // @private
 // @kind function
-// @category utility
-// @fileoverview If set to `1b` deprecation warnings are ignored
-i.ignoreWarning:0b
-
-// @private
-// @kind function
 // @category deprecation
 // @fileoverview Mapping between old names and new names - can read from file
 i.versionMap:.j.k raze read0 hsym`$path,"/util/functionMapping.json"
@@ -505,14 +499,14 @@ i.versionMap:.j.k raze read0 hsym`$path,"/util/functionMapping.json"
 // @category utility
 // @fileoverview Warning function
 i.deprecatedWarning:"Deprecation Warning: function no longer supported as of",
-  " version "
+  " version '"
 
 // @private
 // @kind function
 // @category utility
 // @fileoverview Warning function
 i.futureWarning:"Future Deprecation Warning: function will no longer be ",
-  "callable after "
+  "callable after version '"
 
 // @private
 // @kind function
@@ -526,7 +520,8 @@ i.futureWarning:"Future Deprecation Warning: function will no longer be ",
 // @returns {any} Results from the function
 i.depWarn :{[func;warn;ver;res]
   if[not i.ignoreWarning;
-    -1 get[".ml.i.",warn],ver,". Please use '",func,"' instead."
+    depFunction:$[warn~"deprecatedWarning";{'x};-1];
+    depFunction get[".ml.i.",warn],ver,"'. Please use '",func,"' instead."
     ];
   res
   }

--- a/xval/init.q
+++ b/xval/init.q
@@ -2,4 +2,5 @@
 .ml.loadfile`:xval/xval.q
 .ml.loadfile`:xval/utils.q
 
-.ml.i.deprecWarning[`xval]
+.ml.loadfile`:util/utils.q
+.ml.i.deprecWarning`xval


### PR DESCRIPTION
* Changed a number of less readable abbreviations
* Naming fix for list of functions that rely on Python `.ml.fresh.i.pyFeat`
* Added deprecation warning loading functionality into all initialization steps to avoid need for this addition at a later date
* Deprecated functionality (completely unsupported) now results in an error rather than a warning
* ` updateIgnoreWarning` and associated boolean now defined in `ml/ml.q` s.t. they are definitely available at all times
* Error in label encoding functionality for fitPredict