### PR TITLE
Updates resulting from review of clustering refactor/update

### DIFF
--- a/clust/aprop.q
+++ b/clust/aprop.q
@@ -13,7 +13,7 @@
 //   without a change in clusters. (::) can be passed in which case the defaults
 //   of (`total`noChange!200 15) will be used
 // @return {dict} Data, input variables, clusters and exemplars 
-//   (`data`inputs`clust`exemplars) re, along with a projection of the
+//   (`data`inputs`clust`exemplars) required, along with a projection of the
 //   predict function
 clust.ap.fit:{[data;df;damp;diag;iter]
   data:clust.i.floatConversion[data];
@@ -24,17 +24,20 @@ clust.ap.fit:{[data;df;damp;diag;iter]
   updDict:defaultDict,iter;
   // Cluster data using AP algo
   modelInfo:clust.i.runAp[data;df;damp;diag;til count data 0;updDict];
-  predictFunc:clust.ap.predict[;modelInfo];
-  `modelInfo`predict!(modelInfo;predictFunc)
+  returnInfo:enlist[`modelInfo]!enlist modelInfo;
+  predictFunc:clust.ap.predict[;returnInfo];
+  returnInfo,enlist[`predict]!enlist predictFunc
   }
 
 // @kind function
 // @category clust
 // @fileoverview Predict clusters using AP config
 // @param data {float[][]} Each column of the data is an individual datapoint
-// @param config  {dict} `data`inputs`clust`exemplars returned by clust.ap.fit
+// @param config  {dict} `data`inputs`clust`exemplars returned by the modelInfo
+//   key from the return of clust.ap.fit
 // @return {long[]} Predicted clusters
 clust.ap.predict:{[data;config]
+  config:config`modelInfo;
   data:clust.i.floatConversion[data];
   if[-1~first config`clust;
     '"'.ml.clust.ap.fit' did not converge, all clusters returned -1.",

--- a/clust/kmeans.q
+++ b/clust/kmeans.q
@@ -6,15 +6,22 @@
 // @category clust
 // @fileoverview Fit k-Means algorithm to data
 // @param data {float[][]} Each column of the data is an individual datapoint
-// @param df {sym} Distance function name within '.ml.clust.df'
+// @param df {sym} Distance function name within '.ml.clust.i.df'
 // @param k {long} Number of clusters
 // @param config {dict} Configuration information which can be updated, (::) 
 //   allows a user to use default values, allows update for to maximum 
-//   iterations `iter, initialisation type `init and threshold for smallest 
-//   distance to move between the previous and new run `thresh
-// @return {dict} Model config `data`df`repPts`clt where data and df are the
-//   inputs, repPts are the calculated k means and clt are the associated 
-//   clusters
+//   iterations `iter, initialisation type `init i.e. use k++ or random and
+//   the threshold for smallest distance to move between the previous and
+//   new run `thresh, a distance less than thresh will result in
+//   early stopping
+// @return {dict} A dictionary containing:
+//   - modelInfo which encapsulates all relevant information needed to fit
+//     the model `data`df`repPts`clt, where data and df are the inputs,
+//     repPts are the calculated k centers and clt are clusters associated
+//     with each of the datapoints
+//   - predict is a projection allowing for prediction on new input data
+//   - update is a projection allowing new data to be used to update
+//     cluster centers such that the model can react to new data
 clust.kmeans.fit:{[data;df;k;config]
   data:clust.i.floatConversion[data];
   defaultDict:`iter`init`thresh!(100;1b;1e-5);
@@ -27,20 +34,29 @@ clust.kmeans.fit:{[data;df;k;config]
   // Return config with new clusters
   inputDict:`df`k`iter`kpp!(df;k;updDict`iter;updDict`init);
   modelInfo:r,`data`inputs!(data;inputDict);
-  predictFunc:clust.kmeans.predict[;modelInfo];
-  updFunc:clust.kmeans.update[;modelInfo];
-  `modelInfo`predict`update!(modelInfo;predictFunc;updFunc)
+  returnInfo:enlist[`modelInfo]!enlist modelInfo;
+  predictFunc:clust.kmeans.predict[;returnInfo];
+  updFunc:clust.kmeans.update[;returnInfo];
+  returnInfo,`predict`update!(predictFunc;updFunc)
   }
 
 // @kind function
 // @category clust
 // @fileoverview Predict clusters using k-means config
 // @param data {float[][]} Each column of the data is an individual datapoint
-// @param df {sym} Distance function name within '.ml.clust.df'
-// @param config {dict} `data`df`repPts`clt returned from kmeans clustered 
-//   training data
+// @param df {sym} Distance function name within '.ml.clust.i.df'
+// @param config {dict} A dictionary returned from '.ml.clust.kmeans.fit'
+//   containing
+//   - modelInfo which encapsulates all relevant information needed to fit
+//     the model `data`df`repPts`clt, where data and df are the inputs,
+//     repPts are the calculated k centers and clt are clusters associated
+//     with each of the datapoints
+//   - predict is a projection allowing for prediction on new input data
+//   - update is a projection allowing new data to be used to update
+//     cluster centers such that the model can react to new data
 // @return {long[]} Predicted clusters
 clust.kmeans.predict:{[data;config]
+  config:config[`modelInfo];
   data:clust.i.floatConversion[data];
   // Get new clusters based on latest config
   clust.i.getClust[data;config[`inputs]`df;config`repPts]
@@ -50,19 +66,32 @@ clust.kmeans.predict:{[data;config]
 // @category clust
 // @fileoverview Update kmeans config including new data points
 // @param data {float[][]} Each column of the data is an individual datapoint
-// @param config {dict} `data`df`repPts`clt returned from kmeans clustered 
-//   on training data
-// @return {dict} Updated model config
+// @param config {dict} A dictionary returned from '.ml.clust.kmeans.fit'
+//   containing:
+//   - modelInfo which encapsulates all relevant information needed to fit
+//     the model `data`df`repPts`clt, where data and df are the inputs,
+//     repPts are the calculated k centers and clt are clusters associated
+//     with each of the datapoints
+//   - predict is a projection allowing for prediction on new input data
+//   - update is a projection allowing new data to be used to update
+//     cluster centers such that the model can react to new data
+// @return {dict} Updated model configuration (config), including predict 
+//   and update functions
 clust.kmeans.update:{[data;config]
+  modelConfig:config[`modelInfo];
   data:clust.i.floatConversion[data];
   // Update data to include new points
-  config[`data]:config[`data],'data;
+  modelConfig[`data]:modelConfig[`data],'data;
   // Update k means
-  config[`repPts]:clust.i.updCenters
-    [config`data;config[`inputs]`df;()!();config`repPts];
+  modelConfig[`repPts]:clust.i.updCenters
+    [modelConfig`data;modelConfig[`inputs]`df;()!();modelConfig`repPts];
   // Get updated clusters based on new means
-  config[`clust]:clust.i.getClust
-    [config`data;config[`inputs]`df;config`repPts];
-  // Return updated config
-  config
+  modelConfig[`clust]:clust.i.getClust
+    [modelConfig`data;modelConfig[`inputs]`df;modelConfig`repPts];
+  // Return updated config, prediction and update functions
+  returnInfo:enlist[`modelInfo]!enlist modelConfig;
+  returnKeys:`predict`update;
+  returnVals:(clust.kmeans.predict[;returnInfo];
+    clust.kmeans.update[;returnInfo]);
+  returnInfo,returnKeys!returnVals
   }

--- a/clust/score.q
+++ b/clust/score.q
@@ -20,23 +20,10 @@ clust.daviesBouldin:{[data;clusts]
   }
 
 // @kind function
-// @category clustUtility
-// @fileoverview Davies-Bouldin of a single index
-// @param avgDist {float} Average distance between clusters and average value 
-// @param avgClust {float} Average value of each cluster 
-// @param idx {int[]} All indices of cluster
-// @param n {int} Single index of the cluster group
-// @return {float} Davies Bouldin index of single point
-clust.i.daviesBouldin:{[avgDist;avgClust;idx;n]
-  dists:clust.i.dists[flip avgClust updIdx:idx _n;`edist;avgClust n;::];
-  max(avgDist[n]+avgDist updIdx)%'dists
-  }
-
-// @kind function
 // @category clust
 // @fileoverview Dunn index
 // @param data {float[][]} Each column of the data is an individual datapoint
-// @param df {sym} Distance function name within '.ml.clust.df'
+// @param df {sym} Distance function name within '.ml.clust.i.df'
 // @param clusts {long[]} Clusters produced by .ml.clust algos
 // @return {float} Dunn index of clusts
 clust.dunn:{[data;df;clusts]
@@ -51,9 +38,10 @@ clust.dunn:{[data;df;clusts]
 // @category clust
 // @fileoverview Silhouette score
 // @param data {float[][]} Each column of the data is an individual datapoint
-// @param df {sym} Distance function name within '.ml.clust.df'
+// @param df {sym} Distance function name within '.ml.clust.i.df'
 // @param clusts {long[]} Clusters produced by .ml.clust algos
-// @param isAvg {bool} Scores or the average score (1/0b)
+// @param isAvg {bool} Are all scores(1b) or the average score (0b)
+//   to be returned
 // @return {float} Silhouette score of clusts
 clust.silhouette:{[data;df;clusts;isAvg]
   k:1%(count each group clusts)-1;
@@ -70,7 +58,7 @@ clust.silhouette:{[data;df;clusts;isAvg]
 // @return {float} Homogeneity score for true
 clust.homogeneity:{[pred;true]
   if[count[pred]<>n:count true;
-    '`$"pred and true must have equal lengths"
+    '"pred and true must have equal lengths"
     ];
   if[not ent:clust.i.entropy true;:1.];
   confMat:value confMatrix[pred;true];
@@ -85,7 +73,7 @@ clust.homogeneity:{[pred;true]
 // @category clust
 // @fileoverview Elbow method
 // @param data {float[][]} Each column of the data is an individual datapoint
-// @param df {sym} Distance function name within '.ml.clust.df'
+// @param df {sym} Distance function name within '.ml.clust.i.df'
 // @param k {long} Max number of clusters
 // @return {float[]} Score for each k value - plot to find elbow
 clust.elbow:{[data;df;k]

--- a/clust/tests/clt.t
+++ b/clust/tests/clt.t
@@ -15,13 +15,14 @@ fclust:.p.import[`scipy.cluster.hierarchy]`:fcluster
 mat        :{"f"$flip value flip x}
 clusterIdxs:{value group(x . y)[`modelInfo;`clust]}
 clusterKeys:{key   group(x . y)[`modelInfo;`clust]}
-clusterIdxsUpd:{value group(x . y)`clust}
+clusterIdxsDendro:{value group(x . y)`clust}
+clusterIdxsUpd:{value group(x . y)[`modelInfo;`clust]}
 clusterAdd1:{1+(x . y)`clust}
 qDendrogram:{asc each x(y . z)[`modelInfo;`dgram]}
 algoOutputs:{asc key x . y}
 algoOutputsFit:{asc key first x . y}
 countOutput:{count x y}
-pythonRes  :{[fclust;mat;t;clust;param]value group fclust[mat t`dgram;clust;param]`}[fclust;mat]
+pythonRes  :{[fclust;mat;t;clust;param]value group fclust[mat t[`modelInfo;`dgram];clust;param]`}[fclust;mat]
 pythonDgram:{[lnk;d;lf;df]asc each lnk[flip d;lf;df]`}[lnk]
 qDgramDists:{(x . y)[`modelInfo;`dgram]`dist}
 
@@ -57,7 +58,8 @@ failingTest[.ml.clust.ap.fit;(100?`8;`nege2dist;0.7;min;(::));0b;"Dataset not su
 passingTest[.ml.clust.ap.fit[d1tts 0;`nege2dist;0.7;min;(::)]`predict;d1tts 1;1b;APclt]
 passingTest[.ml.clust.ap.fit[d1tts 0;`nege2dist;0.7;med;`maxrun`maxmatch!100 10]`predict;d1tts 1;1b;APclt]
 failingTest[.ml.clust.ap.fit[d1tts 0;`nege2dist;0.7;min;(::)]`predict;100?`7;1b;"Dataset not suitable for clustering. Must be convertible to floats."]
-failingTest[.ml.clust.ap.predict;(d1tts 1;enlist[`clust]!enlist -1);0b;"'.ml.clust.ap.fit' did not converge, all clusters returned -1. Cannot predict new data."]
+failingTest[.ml.clust.ap.predict;(d1tts 1;enlist[`modelInfo]!enlist enlist[`clust]!enlist -1);
+            0b;"'.ml.clust.ap.fit' did not converge, all clusters returned -1. Cannot predict new data."]
 
 // K-Means
 
@@ -81,7 +83,7 @@ passingTest[countOutput[.ml.clust.kmeans.fit[d1tts 0;`edist;4;kMeansCfg]`predict
 failingTest[.ml.clust.kmeans.fit[d1tts 0;`e2dist;4;kMeansCfg]`predict;100?`4;1b;"Dataset not suitable for clustering. Must be convertible to floats."]
 
 // Update
-passingTest[algoOutputs[.ml.clust.kmeans.fit[d1tts 0;`edist;4;kMeansCfg]`update];enlist d1tts 1;1b;`clust`data`inputs`repPts]
+passingTest[algoOutputs[.ml.clust.kmeans.fit[d1tts 0;`edist;4;kMeansCfg]`update];enlist d1tts 1;1b;`modelInfo`predict`update]
 passingTest[clusterIdxsUpd[.ml.clust.kmeans.fit[d1tts 0;`e2dist;4;kMeansCfg]`update];enlist d1tts 1;1b;d1clt]
 failingTest[.ml.clust.kmeans.update;(1000?`2;()!());0b;"Dataset not suitable for clustering. Must be convertible to floats."]
 
@@ -108,8 +110,8 @@ failingTest[.ml.clust.dbscan.fit[d1tts 0;`e2dist;5;5]`predict;(50?`x`y);1b;"Data
 passingTest[clusterIdxsUpd[.ml.clust.dbscan.fit[d1tts 0;`e2dist;5;5]`update];enlist d1tts 1;1b;d1clt]
 passingTest[clusterIdxsUpd[.ml.clust.dbscan.fit[d1tts 0;`edist;5;5]`update];enlist d1tts 1;1b;d1clt]
 passingTest[clusterIdxsUpd[.ml.clust.dbscan.fit[d1tts 0;`mdist;5;5]`update];enlist d1tts 1;1b;d1clt]
-passingTest[algoOutputs[.ml.clust.dbscan.fit[d1tts 0;`mdist;5;5]`update];enlist d1tts 1;1b;`clust`data`inputs`tab]
-failingTest[.ml.clust.dbscan.update;(50?`x`y;());0b;"Dataset not suitable for clustering. Must be convertible to floats."]
+passingTest[algoOutputs[.ml.clust.dbscan.fit[d1tts 0;`mdist;5;5]`update];enlist d1tts 1;1b;`modelInfo`predict`update]
+failingTest[.ml.clust.dbscan.update;(50?`x`y;()!());0b;"Dataset not suitable for clustering. Must be convertible to floats."]
 
 // CURE
 
@@ -122,23 +124,23 @@ cured1pred2:0 3 0 0 3 3 0 0 0 0 0 3 0 3 3
 cured1pred3:1 3 1 3 3 3 1 1 1 1 1 3 1 3 3
 
 // Fit
-passingTest[clusterIdxsUpd[.ml.clust.cure.cutK];(.ml.clust.cure.fit[d1;`e2dist;5;0]`modelInfo;4);1b;d1clt]
-passingTest[clusterIdxsUpd[.ml.clust.cure.cutK];(.ml.clust.cure.fit[d1;`edist;10;0.2]`modelInfo;4);1b;d1clt]
-passingTest[clusterIdxsUpd[.ml.clust.cure.cutK];(.ml.clust.cure.fit[d1;`mdist;3;0.15]`modelInfo;4);1b;d1clt]
-passingTest[clusterIdxsUpd[.ml.clust.cure.cutK];(.ml.clust.cure.fit[d2;`e2dist;20;0]`modelInfo;4);1b;cured2clt1]
-passingTest[clusterIdxsUpd[.ml.clust.cure.cutK];(.ml.clust.cure.fit[d2;`edist;20;0.2]`modelInfo;4);1b;cured2clt2]
-passingTest[clusterIdxsUpd[.ml.clust.cure.cutK];(.ml.clust.cure.fit[d2;`mdist;10;0.1]`modelInfo;4);1b;cured2clt3]
-passingTest[clusterIdxsUpd[.ml.clust.cure.cutDist];(.ml.clust.cure.fit[d1;`e2dist;5;0]`modelInfo;2.);1b;d1clt]
-passingTest[clusterIdxsUpd[.ml.clust.cure.cutDist];(.ml.clust.cure.fit[d1;`edist;10;0.2]`modelInfo;2.);1b;d1clt]
-passingTest[clusterIdxsUpd[.ml.clust.cure.cutDist];(.ml.clust.cure.fit[d1;`mdist;3;0.15]`modelInfo;2.);1b;d1clt]
+passingTest[clusterIdxsDendro[.ml.clust.cure.cutK];(.ml.clust.cure.fit[d1;`e2dist;5;0];4);1b;d1clt]
+passingTest[clusterIdxsDendro[.ml.clust.cure.cutK];(.ml.clust.cure.fit[d1;`edist;10;0.2];4);1b;d1clt]
+passingTest[clusterIdxsDendro[.ml.clust.cure.cutK];(.ml.clust.cure.fit[d1;`mdist;3;0.15];4);1b;d1clt]
+passingTest[clusterIdxsDendro[.ml.clust.cure.cutK];(.ml.clust.cure.fit[d2;`e2dist;20;0];4);1b;cured2clt1]
+passingTest[clusterIdxsDendro[.ml.clust.cure.cutK];(.ml.clust.cure.fit[d2;`edist;20;0.2];4);1b;cured2clt2]
+passingTest[clusterIdxsDendro[.ml.clust.cure.cutK];(.ml.clust.cure.fit[d2;`mdist;10;0.1];4);1b;cured2clt3]
+passingTest[clusterIdxsDendro[.ml.clust.cure.cutDist];(.ml.clust.cure.fit[d1;`e2dist;5;0];2.);1b;d1clt]
+passingTest[clusterIdxsDendro[.ml.clust.cure.cutDist];(.ml.clust.cure.fit[d1;`edist;10;0.2];2.);1b;d1clt]
+passingTest[clusterIdxsDendro[.ml.clust.cure.cutDist];(.ml.clust.cure.fit[d1;`mdist;3;0.15];2.);1b;d1clt]
 passingTest[algoOutputsFit[.ml.clust.cure.fit];(d1;`e2dist;5;0);1b;`data`dgram`inputs]
 failingTest[.ml.clust.cure.fit;(821?`2;`e2dist;5;0);0b;"Dataset not suitable for clustering. Must be convertible to floats."]
 failingTest[.ml.clust.cure.fit;(d1;`newmetric;5;0);0b;"invalid distance metric"]
 
 // FitPredict
-passingTest[clusterIdxsUpd[.ml.clust.cure.fitPredict];(d1;`e2dist;5;0;enlist[`k]!enlist 4);1b;d1clt]
-passingTest[clusterIdxsUpd[.ml.clust.cure.fitPredict];(d1;`edist;10;0.2;enlist[`k]!enlist 4);1b;d1clt]
-passingTest[clusterIdxsUpd[.ml.clust.cure.fitPredict];(d1;`mdist;3;0.15;enlist[`k]!enlist 4);1b;d1clt]
+passingTest[clusterIdxsDendro[.ml.clust.cure.fitPredict];(d1;`e2dist;5;0;enlist[`k]!enlist 4);1b;d1clt]
+passingTest[clusterIdxsDendro[.ml.clust.cure.fitPredict];(d1;`edist;10;0.2;enlist[`k]!enlist 4);1b;d1clt]
+passingTest[clusterIdxsDendro[.ml.clust.cure.fitPredict];(d1;`mdist;3;0.15;enlist[`k]!enlist 4);1b;d1clt]
 
 // Predict
 passingTest[.ml.clust.cure.fit[d1tts 0;`e2dist;5;0]`predict;(d1tts 1;enlist[`k]!enlist 4);0b;cured1pred1]
@@ -154,11 +156,11 @@ hcResWard:(.ml.arange[0;43;2],(43+(til 80)),124 126 132 142 146 160;(.ml.arange[
 hcResCentroid:((til 123);.ml.arange[123;194;2];.ml.arange[124;199;2];195 197 199)
 hcResComplete:(.ml.arange[0;43;2],(43+(til 80));(.ml.arange[1;43;2]);.ml.arange[123;200;2];.ml.arange[124;200;2])
 hcResAverage:(.ml.arange[0;27;2],27,.ml.arange[28;43;2],43+(til 80);(.ml.arange[1;27;2],.ml.arange[29;42;2]);.ml.arange[123;200;2];.ml.arange[124;200;2])
-tab1:.ml.clust.hc.fit[d1;`mdist ;`single]`modelInfo
-tab2:.ml.clust.hc.fit[d1;`e2dist;`average]`modelInfo
-tab3:.ml.clust.hc.fit[d2;`e2dist;`centroid]`modelInfo
-tab4:.ml.clust.hc.fit[d2;`edist ;`complete]`modelInfo
-hct1fit:"j"$fclust[mat tab1`dgram;4;`maxclust]`
+tab1:.ml.clust.hc.fit[d1;`mdist ;`single]
+tab2:.ml.clust.hc.fit[d1;`e2dist;`average]
+tab3:.ml.clust.hc.fit[d2;`e2dist;`centroid]
+tab4:.ml.clust.hc.fit[d2;`edist ;`complete]
+hct1fit:"j"$fclust[mat tab1[`modelInfo;`dgram];4;`maxclust]`
 hcd1pred1:1 2 1 1 2 2 1 1 1 1 1 2 1 2 2
 hcd1pred2:1 3 1 1 3 3 1 1 1 1 1 3 1 3 3
 hcd1pred3:1 3 1 1 3 3 1 1 1 1 1 3 1 3 3
@@ -166,18 +168,18 @@ pyDgramDists:(lnk[flip d2;`single;`sqeuclidean]`)[;2]
 
 // Fit
 passingTest[clusterAdd1[.ml.clust.hc.cutK   ];(tab1;4);1b;hct1fit]
-passingTest[clusterIdxsUpd[.ml.clust.hc.cutK];(.ml.clust.hc.fit[d2;`e2dist;`single]`modelInfo;4);1b;hcResSingle]
-passingTest[clusterIdxsUpd[.ml.clust.hc.cutK];(.ml.clust.hc.fit[d2;`e2dist;`ward]`modelInfo;4);1b;hcResWard]
-passingTest[clusterIdxsUpd[.ml.clust.hc.cutK];(.ml.clust.hc.fit[d2;`edist;`centroid]`modelInfo;4);1b;hcResCentroid]
-passingTest[clusterIdxsUpd[.ml.clust.hc.cutK];(.ml.clust.hc.fit[d2;`edist;`complete]`modelInfo;4);1b;hcResComplete]
-passingTest[clusterIdxsUpd[.ml.clust.hc.cutK];(.ml.clust.hc.fit[d2;`mdist;`average]`modelInfo;4);1b;hcResAverage]
-passingTest[clusterIdxsUpd[.ml.clust.hc.cutK];(tab2;4);1b;pythonRes[tab2;4;`maxclust]]
-passingTest[clusterIdxsUpd[.ml.clust.hc.cutK];(tab3;4);1b;pythonRes[tab3;4;`maxclust]]
-passingTest[clusterIdxsUpd[.ml.clust.hc.cutK];(tab4;4);1b;pythonRes[tab4;4;`maxclust]]
-passingTest[clusterIdxsUpd[.ml.clust.hc.cutDist];(tab1;.45);1b;pythonRes[tab1;.45;`distance]]
-passingTest[clusterIdxsUpd[.ml.clust.hc.cutDist];(tab2;4);1b;pythonRes[tab2;34;`distance]]
-passingTest[clusterIdxsUpd[.ml.clust.hc.cutDist];(tab3;500);1b;pythonRes[tab3;500;`distance]]
-passingTest[clusterIdxsUpd[.ml.clust.hc.cutDist];(tab4;30);1b;pythonRes[tab4;30;`distance]]
+passingTest[clusterIdxsDendro[.ml.clust.hc.cutK];(.ml.clust.hc.fit[d2;`e2dist;`single];4);1b;hcResSingle]
+passingTest[clusterIdxsDendro[.ml.clust.hc.cutK];(.ml.clust.hc.fit[d2;`e2dist;`ward];4);1b;hcResWard]
+passingTest[clusterIdxsDendro[.ml.clust.hc.cutK];(.ml.clust.hc.fit[d2;`edist;`centroid];4);1b;hcResCentroid]
+passingTest[clusterIdxsDendro[.ml.clust.hc.cutK];(.ml.clust.hc.fit[d2;`edist;`complete];4);1b;hcResComplete]
+passingTest[clusterIdxsDendro[.ml.clust.hc.cutK];(.ml.clust.hc.fit[d2;`mdist;`average];4);1b;hcResAverage]
+passingTest[clusterIdxsDendro[.ml.clust.hc.cutK];(tab2;4);1b;pythonRes[tab2;4;`maxclust]]
+passingTest[clusterIdxsDendro[.ml.clust.hc.cutK];(tab3;4);1b;pythonRes[tab3;4;`maxclust]]
+passingTest[clusterIdxsDendro[.ml.clust.hc.cutK];(tab4;4);1b;pythonRes[tab4;4;`maxclust]]
+passingTest[clusterIdxsDendro[.ml.clust.hc.cutDist];(tab1;.45);1b;pythonRes[tab1;.45;`distance]]
+passingTest[clusterIdxsDendro[.ml.clust.hc.cutDist];(tab2;4);1b;pythonRes[tab2;34;`distance]]
+passingTest[clusterIdxsDendro[.ml.clust.hc.cutDist];(tab3;500);1b;pythonRes[tab3;500;`distance]]
+passingTest[clusterIdxsDendro[.ml.clust.hc.cutDist];(tab4;30);1b;pythonRes[tab4;30;`distance]]
 passingTest[qDendrogram[mat;.ml.clust.hc.fit];(d1;`e2dist;`single);1b;pythonDgram[d1;`single;`sqeuclidean]]
 passingTest[qDendrogram[mat;.ml.clust.hc.fit];(d1;`mdist;`complete);1b;pythonDgram[d1;`complete;`cityblock]]
 passingTest[qDendrogram[mat;.ml.clust.hc.fit];(d1;`edist;`centroid);1b;pythonDgram[d1;`centroid;`euclidean]]
@@ -188,9 +190,9 @@ failingTest[.ml.clust.hc.fit;(d1;`mdist;`ward);0b;"ward must be used with e2dist
 failingTest[.ml.clust.hc.fit;(d1;`mdist;`linkage);0b;"invalid linkage"]
 
 // FitPredict
-passingTest[clusterIdxsUpd[.ml.clust.hc.fitPredict];(d2;`e2dist;`single;enlist[`k]!enlist 4);1b;hcResSingle]
-passingTest[clusterIdxsUpd[.ml.clust.hc.fitPredict];(d2;`e2dist;`ward;enlist[`k]!enlist 4);1b;hcResWard]
-passingTest[clusterIdxsUpd[.ml.clust.hc.fitPredict];(d2;`edist;`centroid;enlist[`k]!enlist 4);1b;hcResCentroid]
+passingTest[clusterIdxsDendro[.ml.clust.hc.fitPredict];(d2;`e2dist;`single;enlist[`k]!enlist 4);1b;hcResSingle]
+passingTest[clusterIdxsDendro[.ml.clust.hc.fitPredict];(d2;`e2dist;`ward;enlist[`k]!enlist 4);1b;hcResWard]
+passingTest[clusterIdxsDendro[.ml.clust.hc.fitPredict];(d2;`edist;`centroid;enlist[`k]!enlist 4);1b;hcResCentroid]
 
 // Predict
 passingTest[.ml.clust.hc.fit[d1tts 0;`e2dist;`single]`predict;(d1tts 1;enlist[`k]!enlist 4);0b;hcd1pred1]


### PR DESCRIPTION
The changes enacted by the following update can be outlined as follows
* Prediction functions now take as input the output from fit functions rather than the ``` `modelInfo``` key of the return.
* The update functions for kmeans and dbscan return a structure which can now be iteratively updated
* Tests updated in line with above changes
* Addition of some error conditions for hierarchical clustering when K is < 1 or the distance to split the dendrogram is too large.
*  Moved some functions that are utilities from `score.q` to `utils.q`
*  Minor structuring/spelling updates